### PR TITLE
接入 Tracy profiler(HORIZON_ENABLE_TRACY,默认关闭)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,7 @@ option(HORIZON_ENABLE_DEBUG_VALIDATION "Enable Horizon hardware checks and Vulka
 option(HORIZON_ENABLE_RELWITHDEBINFO_VALIDATION "Enable Horizon hardware checks and Vulkan validation layers in RelWithDebInfo builds" OFF)
 option(HORIZON_ENABLE_RELEASE_VALIDATION "Enable Horizon hardware checks and Vulkan validation layers in Release and MinSizeRel builds" OFF)
 option(HORIZON_ENABLE_HARDCODE_SHADERS "Compile and use generated Helicon hardcoded shader cache" OFF)
+option(HORIZON_ENABLE_TRACY "Enable Tracy profiler instrumentation" OFF)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -48,6 +49,7 @@ include(FetchContent)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/HorizonFetchContent.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/HorizonSlang.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/HorizonCoreDependencies.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/HorizonTracy.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/HorizonRuntimeDeps.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/HorizonCorona.cmake)
 

--- a/cmake/HorizonTracy.cmake
+++ b/cmake/HorizonTracy.cmake
@@ -1,0 +1,21 @@
+include_guard(GLOBAL)
+
+# ======================== Tracy Profiler ========================
+# HORIZON_ENABLE_TRACY=OFF 时不拉取、不链接，埋点宏全部展开为空。
+if(NOT HORIZON_ENABLE_TRACY)
+    return()
+endif()
+
+set(TRACY_ENABLE ON CACHE BOOL "" FORCE)
+# ON_DEMAND: 仅在 Tracy Profiler UI 连接时才采集，未连接时运行开销接近零。
+# 若需要从进程启动第一帧就开始采集，把这一项改为 OFF。
+set(TRACY_ON_DEMAND ON CACHE BOOL "" FORCE)
+set(TRACY_STATIC ON CACHE BOOL "" FORCE)
+
+horizon_fetchcontent_declare(
+    tracy
+    GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+    GIT_TAG v0.13.1
+    EXCLUDE_FROM_ALL
+)
+FetchContent_MakeAvailable(tracy)

--- a/include/horizon_profiling.h
+++ b/include/horizon_profiling.h
@@ -1,0 +1,28 @@
+#pragma once
+
+// Tracy instrumentation wrapper. When HORIZON_ENABLE_TRACY is OFF the macros
+// expand to nothing, so call sites never need #ifdef guards.
+#if defined(HORIZON_TRACY_ENABLED)
+
+#include <tracy/Tracy.hpp>
+
+// Marks the end of a frame (call once per presented frame).
+#define HORIZON_PROFILE_FRAME() FrameMark
+// Scoped CPU zone named after the enclosing function.
+#define HORIZON_PROFILE_SCOPE() ZoneScoped
+// Scoped CPU zone with an explicit name (string literal).
+#define HORIZON_PROFILE_SCOPE_N(name) ZoneScopedN(name)
+// Plots a numeric value over time (name must be a string literal).
+#define HORIZON_PROFILE_PLOT(name, value) TracyPlot(name, static_cast<double>(value))
+// Names the current thread in the Tracy UI.
+#define HORIZON_PROFILE_THREAD(name) tracy::SetThreadName(name)
+
+#else
+
+#define HORIZON_PROFILE_FRAME()
+#define HORIZON_PROFILE_SCOPE()
+#define HORIZON_PROFILE_SCOPE_N(name)
+#define HORIZON_PROFILE_PLOT(name, value)
+#define HORIZON_PROFILE_THREAD(name)
+
+#endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,13 @@ target_link_libraries(Horizon PUBLIC
     VulkanMemoryAllocator
 )
 
+# Tracy 采集客户端；PUBLIC 传递给 examples 等下游目标，
+# 使它们也能直接使用 horizon_profiling.h 中的埋点宏。
+if(HORIZON_ENABLE_TRACY)
+    target_link_libraries(Horizon PUBLIC Tracy::TracyClient)
+    target_compile_definitions(Horizon PUBLIC HORIZON_TRACY_ENABLED=1)
+endif()
+
 # 忽略第三方库（VulkanMemoryAllocator）的 nullability 警告
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     target_compile_options(Horizon PRIVATE

--- a/src/hardware_wrapper_vulkan/display/display_manager.cpp
+++ b/src/hardware_wrapper_vulkan/display/display_manager.cpp
@@ -7,6 +7,8 @@
 
 #include "display_manager.h"
 
+#include "horizon_profiling.h"
+
 #include "hardware_wrapper/diagnostics.h"
 #include "hardware_wrapper_vulkan/hardware/device_manager.h"
 #include "hardware_wrapper_vulkan/hardware/resource_manager.h"
@@ -901,6 +903,10 @@ namespace Corona::Horizon
 
     PresentResult DisplayManager::present(const PresentDesc& desc, const SubmissionToken& producer)
     {
+        HORIZON_PROFILE_SCOPE_N("Horizon::present");
+        // 每次 present 视为一帧结束，作为 Tracy 时间轴上的帧分隔。
+        // 注意：多窗口时各窗口的 present 会混在同一条帧时间轴上。
+        HORIZON_PROFILE_FRAME();
         std::lock_guard lock(mutex_);
 
         PresentResult result;

--- a/src/hardware_wrapper_vulkan/hardware/device_manager.cpp
+++ b/src/hardware_wrapper_vulkan/hardware/device_manager.cpp
@@ -1,5 +1,6 @@
 #include "device_manager.h"
 #include "execution_profile.h"
+#include "horizon_profiling.h"
 
 #include <algorithm>
 #include <atomic>
@@ -544,6 +545,7 @@ namespace Corona::Horizon
                                   std::span<const SubmitSignal> signals,
                                   ExecutionCommitProfileSample* profile)
     {
+        HORIZON_PROFILE_SCOPE_N("Horizon::queue_submit");
         std::vector<VkSemaphoreSubmitInfo> wait_infos;
         wait_infos.reserve(waits.size());
         for (const SubmitWait& wait : waits)

--- a/src/hardware_wrapper_vulkan/hardware/execution.cpp
+++ b/src/hardware_wrapper_vulkan/hardware/execution.cpp
@@ -1,5 +1,7 @@
 #include "execution.h"
 
+#include "horizon_profiling.h"
+
 #include "device_manager.h"
 #include "hardware_wrapper/diagnostics.h"
 #include "hardware_wrapper_vulkan/display/display_manager.h"
@@ -1162,6 +1164,7 @@ namespace Corona::Horizon
 
     ExecutionPlan ExecutionCompiler::compile_owned(RecordedTask& task, ExecutionCommitProfileSample* profile) const
     {
+        HORIZON_PROFILE_SCOPE_N("Horizon::compile");
         ExecutionPlan plan;
         std::unordered_map<std::uintptr_t, LastResourceUse> global_last_access;
 
@@ -1303,6 +1306,7 @@ namespace Corona::Horizon
 
     void VulkanCommandEncoder::encode(CompiledSubmission& submission) const
     {
+        HORIZON_PROFILE_SCOPE_N("Horizon::encode");
         if (!submission.command_buffer || submission.command_buffer->vk() == VK_NULL_HANDLE)
         {
             return;
@@ -2309,6 +2313,7 @@ namespace Corona::Horizon
 
     SubmitReceipt HardwareExecutor::commit(RecordedTask task)
     {
+        HORIZON_PROFILE_SCOPE_N("Horizon::commit");
         const auto total_start = std::chrono::steady_clock::now();
         ExecutionCommitProfileSample profile;
         ExecutionCommitProfileScope profile_scope(profile);
@@ -2329,6 +2334,12 @@ namespace Corona::Horizon
         profile.total_ms = std::chrono::duration<double, std::milli>(
             std::chrono::steady_clock::now() - total_start).count();
         record_execution_commit_profile(profile);
+        HORIZON_PROFILE_PLOT("commit total (ms)", profile.total_ms);
+        HORIZON_PROFILE_PLOT("commit compile (ms)", profile.compile_ms);
+        HORIZON_PROFILE_PLOT("commit encode (ms)", profile.encode_ms);
+        HORIZON_PROFILE_PLOT("commit vk submit (ms)", profile.queue_submit_ms);
+        HORIZON_PROFILE_PLOT("commit present (ms)", profile.present_ms);
+        HORIZON_PROFILE_PLOT("commit commands", profile.commands);
         return receipt;
     }
 


### PR DESCRIPTION
- cmake/HorizonTracy.cmake: FetchContent 拉取 Tracy v0.13.1,TRACY_ON_DEMAND 模式
- include/horizon_profiling.h: 埋点宏封装,开关关闭时全部空展开,调用处无需 #ifdef
- 埋点覆盖 commit/compile/encode/queue_submit/present 关键路径, present 处打 FrameMark